### PR TITLE
Add option to choose Duplicacy version at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ ENV BACKUP_SCHEDULE='* * * * *' \
     AZURE_KEY='' \
     GCD_TOKEN='' \
     GCS_TOKEN_FILE='' \
-    ONEDRIVE_TOKEN_FILE=''
+    ONEDRIVE_TOKEN_FILE='' \
+    DUPLICACY_VERSION=''
 
 #--
 #-- Other steps

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Use the following environment variables if you want to customize duplicacy's beh
 - `BACKUP_IMMEDIATELY` (`yes`/`no`): indicates if a backup should be performed immediately after the container is started. Equivalent to launching the container and then running `docker exec duplicacy-autobackup /app/duplicacy-autobackup.sh backup`. By default, `no`.
 - `DUPLICACY_INIT_OPTIONS`: options passed to `duplicacy init` the first time a backup is made. By default, `-encrypt` if `BACKUP_ENCRYPTION_KEY` is not empty.
 - `DUPLICACY_BACKUP_OPTIONS`: options passed to `duplicacy backup` when a backup is performed. By default: `-threads 4 -stats`. **If you are backing up a hard drive (and not a SSD), it is recommended to use `-threads 1 -stats` instead** (see [here](https://duplicacy.com/issue?id=5670666258874368) for more details).
+- `DUPLICACY_VERSION`: version of the Duplicacy CLI that will be downloaded whenever the container starts. (e.g: `2.1.0`)
 
 ## Disclaimer
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+
+if [[ ! -z $DUPLICACY_VERSION ]]; then
+    wget https://github.com/gilbertchen/duplicacy/releases/download/v$DUPLICACY_VERSION/duplicacy_linux_x64_$DUPLICACY_VERSION -O /usr/bin/duplicacy
+    chmod +x /usr/bin/duplicacy
+fi
+
+duplicacy | grep VERSION -A 1
+
 echo "$BACKUP_SCHEDULE /app/duplicacy-autobackup.sh backup" > /var/spool/cron/crontabs/root
 /app/duplicacy-autobackup.sh init
 


### PR DESCRIPTION
This Fix #19 

By allowing one to choose to download the CLI at runtime, we can allow the image to be reused as it is.

This will only be an issue when the CLI commands stop working.