### PR TITLE
Add option to choose Duplicacy version at build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 - docker
 install:
 - mkdir -p /tmp/bin
-- wget https://github.com/gilbertchen/duplicacy/releases/download/v2.1.0/duplicacy_linux_x64_2.1.0 -O /tmp/bin/duplicacy && chmod +x /tmp/bin/duplicacy
+- wget https://github.com/gilbertchen/duplicacy/releases/download/v2.3.0/duplicacy_linux_x64_2.3.0 -O /tmp/bin/duplicacy && chmod +x /tmp/bin/duplicacy
 - export PATH=$PATH:/tmp/bin
 - pip install awscli
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Christophe Tafani-Dereeper <christophe@tafani-dereeper.me>
 #--
 #-- Build variables
 #--
-ARG DUPLICACY_VERSION=2.1.0
+ARG DUPLICACY_VERSION=2.3.0
 
 #--
 #-- Environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM alpine:3.7
 MAINTAINER Christophe Tafani-Dereeper <christophe@tafani-dereeper.me>
 
 #--
+#-- Build variables
+#--
+ARG DUPLICACY_VERSION=2.1.0
+
+#--
 #-- Environment variables
 #--
 
@@ -30,7 +35,7 @@ ENV BACKUP_SCHEDULE='* * * * *' \
 #-- Other steps
 #--
 RUN apk --no-cache add ca-certificates && update-ca-certificates
-RUN wget https://github.com/gilbertchen/duplicacy/releases/download/v2.1.0/duplicacy_linux_x64_2.1.0 -O /usr/bin/duplicacy && \
+RUN wget https://github.com/gilbertchen/duplicacy/releases/download/v${DUPLICACY_VERSION}/duplicacy_linux_x64_${DUPLICACY_VERSION} -O /usr/bin/duplicacy && \
     chmod +x /usr/bin/duplicacy
 
 RUN mkdir /app

--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ Use the following environment variables if you want to customize duplicacy's beh
 - `DUPLICACY_INIT_OPTIONS`: options passed to `duplicacy init` the first time a backup is made. By default, `-encrypt` if `BACKUP_ENCRYPTION_KEY` is not empty.
 - `DUPLICACY_BACKUP_OPTIONS`: options passed to `duplicacy backup` when a backup is performed. By default: `-threads 4 -stats`. **If you are backing up a hard drive (and not a SSD), it is recommended to use `-threads 1 -stats` instead** (see [here](https://duplicacy.com/issue?id=5670666258874368) for more details).
 
+## Choosing the Duplicacy version
+
+You can choose the Duplicacy version that will be used by the container during build time. The `ARG` `DUPLICACY_VERSION` is available for that purpose. e.g:
+
+```
+docker build --build-arg DUPLICACY_VERSION=2.1.0 -t christophetd/duplicacy-autobackup .
+```
+
 ## Disclaimer
 
 This project uses [Duplicacy](https://github.com/gilbertchen/duplicacy), which is free for personal use but requires [purchasing a licence](https://duplicacy.com/buy.html) for non-trial commercial use. See the detailed terms [here](https://github.com/gilbertchen/duplicacy/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Use the following environment variables if you want to customize duplicacy's beh
 
 ## Choosing the Duplicacy version
 
-You can choose the Duplicacy version that will be used by the container during build time. The `ARG` `DUPLICACY_VERSION` is available for that purpose. e.g:
+When building the container, you can choose the Duplicacy version that will be used in the container image. The build argument `DUPLICACY_VERSION` is available for that purpose, e.g.:
 
 ```
 docker build --build-arg DUPLICACY_VERSION=2.1.0 -t christophetd/duplicacy-autobackup .


### PR DESCRIPTION
Fix #19 

- [x] Choose which duplicacy version to use during build time
- [x] Add section on README showing how to build the image
- [x] Use version `2.1.0` as default value for `DUPLICACY_VERSION` for backward compatibility.