### PR TITLE
Bugfix: allow backing up of read-only mount /data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,8 @@ WORKDIR /app
 ADD *.sh ./
 RUN chmod +x *.sh
 
+RUN mkdir /wd
+WORKDIR /wd
+
 VOLUME ["/data"]
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/dispose-symlinks.sh
+++ b/dispose-symlinks.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Delete all files in /wd/ except for .duplicacy
+# This needs rm -f because the symlinks created previously may inherit read-only permissions.
+cd / 
+find /wd/ -mindepth 1 -maxdepth 1 -not -path /wd/.duplicacy -exec rm -f {} \;
+cd - > /dev/null

--- a/duplicacy-autobackup.sh
+++ b/duplicacy-autobackup.sh
@@ -3,7 +3,7 @@
 PRE_BACKUP_SCRIPT="/scripts/pre-backup.sh"
 POST_BACKUP_SCRIPT="/scripts/post-backup.sh"
 
-cd /data
+cd /wd
 
 do_init() {
   : ${BACKUP_NAME:?'Missing BACKUP_NAME'}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,15 @@
 echo "$BACKUP_SCHEDULE /app/duplicacy-autobackup.sh backup" > /var/spool/cron/crontabs/root
 echo "$PRUNE_SCHEDULE /app/duplicacy-autobackup.sh prune" >> /var/spool/cron/crontabs/root
 
+cd /wd
+
 /app/duplicacy-autobackup.sh init
 
 if [[ $BACKUP_IMMEDIATLY == "yes" ]] || [[ $BACKUP_IMMEDIATELY == "yes" ]]; then # two spellings for retro-compatibility
     echo "Running a backup right now"
+    /app/make-symlinks.sh # Create symlinks in /wd/ to items in /data/
     /app/duplicacy-autobackup.sh backup
+    /app/dispose-symlinks.sh
 fi
 
 crond -l 8 -f

--- a/make-symlinks.sh
+++ b/make-symlinks.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Duplicacy will follow symlinks at the top level of the working directory.
+# (Note: these symlinks must point to absolute paths)
+# For each item in /data, create a symlink (of the same name) to its _absolute path_ in /data/
+cd /
+find /data/ -mindepth 1 -maxdepth 1 -exec sh -c 'ln -s "$0" "/wd/$(basename "$0")"' {} \;
+cd - > /dev/null


### PR DESCRIPTION
This commit allows the user to backup mounts at /data which are mounted
as read-only. There is a slight break to previous behaviour which may
affect some users: symlinks inside /data which point to absolute paths
*used* to be followed, and their contents included in the backup. This
is no longer the case.